### PR TITLE
Add regexp.Regexp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ fig is a tiny library for loading an application's config file and its environme
 - Define your **configuration**, **validations** and **defaults** in a single location
 - Optionally **load from the environment** as well
 - Only **3** external dependencies
-- Full support for`time.Time` & `time.Duration`
+- Full support for`time.Time`, `time.Duration` & `regexp.Regexp`
 - Tiny API
 - Decoders for `.yaml`, `.json` and `.toml` files
 
@@ -64,8 +64,9 @@ type Config struct {
     Cleanup time.Duration `fig:"cleanup" default:"30m"`
   }
   Logger struct {
-    Level string `fig:"level" default:"info"`
-    Trace bool   `fig:"trace"`
+    Level   string         `fig:"level" default:"info"`
+    Pattern *regexp.Regexp `fig:"pattern" default:".*"`
+    Trace   bool           `fig:"trace"`
   }
 }
 
@@ -75,7 +76,7 @@ func main() {
   // handle your err
   
   fmt.Printf("%+v\n", cfg)
-  // Output: {Build:2019-12-25 00:00:00 +0000 UTC Server:{Host:127.0.0.1 Ports:[8080] Cleanup:1h0m0s} Logger:{Level:warn Trace:true}}
+  // Output: {Build:2019-12-25 00:00:00 +0000 UTC Server:{Host:127.0.0.1 Ports:[8080] Cleanup:1h0m0s} Logger:{Level:warn Pattern:.* Trace:true}}
 }
 ```
 

--- a/doc.go
+++ b/doc.go
@@ -188,9 +188,10 @@ See example below to help understand:
       I interface{} `validate:"required"`
       J interface{} `validate:"required"`
     } `validate:"required"`
-    K *[]bool    `validate:"required"`
-    L []uint     `validate:"required"`
-    M *time.Time `validate:"required"`
+    K *[]bool        `validate:"required"`
+    L []uint         `validate:"required"`
+    M *time.Time     `validate:"required"`
+    N *regexp.Regexp `validate:"required"`
   }
 
   var cfg Config
@@ -206,7 +207,7 @@ See example below to help understand:
 
   err := fig.Load(&cfg)
   fmt.Print(err)
-  // A: required, B: required, C: required, D: required, E: required, G: required, H.J: required, K: required, M: required
+  // A: required validation failed, B: required validation failed, C: required validation failed, D: required validation failed, E: required validation failed, G: required validation failed, H.J: required validation failed, K: required validation failed, M: required validation failed, N: required validation failed
 
 Default
 
@@ -224,6 +225,7 @@ A default value can be set for the following types:
   all basic types except bool and complex
   time.Time
   time.Duration
+  *regexp.Regexp
   slices (of above types)
 
 Successive elements of slice defaults should be separated by a comma. The entire slice can optionally be enclosed in square brackets:

--- a/examples/config/config.yaml
+++ b/examples/config/config.yaml
@@ -7,6 +7,7 @@ server:
 
 logger:
   level: debug
+  pattern: '[a-z]+'
 
 certificate:
   version: 1

--- a/examples/config/config_test.go
+++ b/examples/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/kkyr/fig"
@@ -18,7 +19,8 @@ type Config struct {
 		WriteTimeout time.Duration `fig:"write_timeout" default:"30s"`
 	} `fig:"server"`
 	Logger struct {
-		Level string `fig:"level" default:"info"`
+		Level   string         `fig:"level" default:"info"`
+		Pattern *regexp.Regexp `fig:"pattern" default:".*"`
 	} `fig:"logger"`
 	Certificate struct {
 		Version    int       `fig:"version"`
@@ -40,6 +42,7 @@ func ExampleLoad() {
 	fmt.Println(cfg.Server.ReadTimeout)
 	fmt.Println(cfg.Server.WriteTimeout)
 	fmt.Println(cfg.Logger.Level)
+	fmt.Println(cfg.Logger.Pattern)
 	fmt.Println(cfg.Certificate.Version)
 	fmt.Println(cfg.Certificate.DNSNames)
 	fmt.Println(cfg.Certificate.Expiration.Format("2006-01-02"))
@@ -51,6 +54,7 @@ func ExampleLoad() {
 	// 1m0s
 	// 30s
 	// debug
+	// [a-z]+
 	// 1
 	// [kkyr kkyr.io]
 	// 2020-12-01

--- a/util_test.go
+++ b/util_test.go
@@ -3,6 +3,7 @@ package fig
 import (
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"testing"
 	"time"
 )
@@ -133,6 +134,22 @@ func Test_isZero(t *testing.T) {
 		td := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 
 		if isZero(reflect.ValueOf(td)) == true {
+			t.Fatalf("isZero == true")
+		}
+	})
+
+	t.Run("zero regexp is zero", func(t *testing.T) {
+		var re *regexp.Regexp
+
+		if isZero(reflect.ValueOf(re)) == false {
+			t.Fatalf("isZero == false")
+		}
+	})
+
+	t.Run("non-zero regexp is not zero", func(t *testing.T) {
+		re := regexp.MustCompile(".*")
+
+		if isZero(reflect.ValueOf(re)) == true {
 			t.Fatalf("isZero == true")
 		}
 	})


### PR DESCRIPTION
It's useful to support validated regular expressions in configuration.
Previously, we could represent these fields as raw pattern strings and
compile them in application code. By supporting Regexp as a first-class
field type, we get a smaller application code and more immediate error
reporting without complicating the API.