### PR TITLE
Allow providing config values only via environment

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,15 +1,14 @@
 /*
-Package fig loads configuration files into Go structs with extra juice for validating fields and setting defaults.
+Package fig loads configuration files and/or environment variables into Go structs with extra juice for validating fields and setting defaults.
 
-Config files may be defined in in yaml, json or toml format.
+Config files may be defined in yaml, json or toml format.
 
 When you call `Load()`, fig takes the following steps:
 
-  1. Finds config file
-  2. Loads file into config struct
-  3. Fills config struct from the environment (if enabled)
-  4. Sets defaults (where applicable)
-  5. Validates required fields (where applicable)
+  1. Fills config struct from the config file (if enabled)
+  2. Fills config struct from the environment (if enabled)
+  3. Sets defaults (where applicable)
+  4. Validates required fields (where applicable)
 
 Example
 
@@ -60,16 +59,22 @@ Define your struct and load it:
    // Output: {Build:2019-12-25 00:00:00 +0000 UTC Server:{Host:127.0.0.1 Ports:[8080] Cleanup:1h0m0s} Logger:{Level:warn Trace:true}}
  }
 
-By default fig searches for a file named `config.yaml` in the directory it is run from.
-It can be configured to look elsewhere.
-
 Configuration
 
 Pass options as additional parameters to `Load()` to configure fig's behaviour.
 
-File
+IgnoreFile
 
-Change the file and directories fig searches in with `File()`.
+Do not look for any configuration file with `IgnoreFile()`.
+
+  fig.Load(&cfg, fig.IgnoreFile())
+
+If IgnoreFile is given then any other configuration file related options like `File` and `Dirs` are simply ignored.
+
+File & Dirs
+
+By default fig searches for a file named `config.yaml` in the directory it is run from. Change the file and directories fig
+searches in with `File()` and `Dirs()`.
 
   fig.Load(&cfg,
     fig.File("settings.json"),
@@ -96,11 +101,11 @@ By default fig uses the tag key `fig`.
 
 Environment
 
-Fig can be configured to additionally set fields using the environment. This will happen after the struct is loaded from a config file and thus any values found in the environment will overwrite existing values in the struct.
+Fig can be configured to additionally set fields using the environment.
+This behaviour can be enabled using the option `UseEnv(prefix)`. If loading from file is also enabled then first the struct is loaded
+from a config file and thus any values found in the environment will overwrite existing values in the struct.
 
-This is meant to be used in conjunction with loading from a file. There is no support to ONLY load from the environment. You could, but you'd still have to provide an (empty) config file.
-
-This behaviour is disabled by default and can be enabled using the option `UseEnv(prefix)`. Prefix is a string that will be prepended to the keys that are searched in the environment. Although discouraged, prefix may be left empty.
+Prefix is a string that will be prepended to the keys that are searched in the environment. Although discouraged, prefix may be left empty.
 
 Fig searches for keys in the form PREFIX_FIELD_PATH, or if prefix is left empty then FIELD_PATH.
 

--- a/fig.go
+++ b/fig.go
@@ -76,6 +76,7 @@ type fig struct {
 	tag        string
 	timeLayout string
 	useEnv     bool
+	ignoreFile bool
 	envPrefix  string
 }
 
@@ -84,14 +85,19 @@ func (f *fig) Load(cfg interface{}) error {
 		return fmt.Errorf("cfg must be a pointer to a struct")
 	}
 
-	file, err := f.findCfgFile()
-	if err != nil {
-		return err
-	}
+	vals := make(map[string]interface{})
 
-	vals, err := f.decodeFile(file)
-	if err != nil {
-		return err
+	if !f.ignoreFile {
+
+		file, err := f.findCfgFile()
+		if err != nil {
+			return err
+		}
+
+		vals, err = f.decodeFile(file)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := f.decodeMap(vals, cfg); err != nil {

--- a/fig.go
+++ b/fig.go
@@ -88,7 +88,6 @@ func (f *fig) Load(cfg interface{}) error {
 	vals := make(map[string]interface{})
 
 	if !f.ignoreFile {
-
 		file, err := f.findCfgFile()
 		if err != nil {
 			return err

--- a/fig_test.go
+++ b/fig_test.go
@@ -405,66 +405,64 @@ func Test_fig_Load_WithOptions(t *testing.T) {
 	}
 }
 
-func Test_fig_Load_NoFile(t *testing.T) {
-	t.Run("NOFILE", func(t *testing.T) {
-		type Server struct {
-			Host   string `custom:"host" default:"127.0.0.1"`
-			Ports  []int  `custom:"ports" default:"[80,443]"`
-			Logger struct {
-				LogLevel string `custom:"log_level"`
-				Metadata struct {
-					Keys []string `custom:"keys" default:"ts"`
-					Tag  string   `custom:"tag" validate:"required"`
-				}
-			}
-			Cache struct {
-				CleanupInterval time.Duration `custom:"cleanup_interval" validate:"required"`
-				FillThreshold   float32       `custom:"threshold" default:"0.9"`
-			}
-			Application struct {
-				BuildDate time.Time `custom:"build_date" default:"12-25-2012"`
-				Version   int
+func Test_fig_Load_IgnoreFile(t *testing.T) {
+	type Server struct {
+		Host   string `custom:"host" default:"127.0.0.1"`
+		Ports  []int  `custom:"ports" default:"[80,443]"`
+		Logger struct {
+			LogLevel string `custom:"log_level"`
+			Metadata struct {
+				Keys []string `custom:"keys" default:"ts"`
+				Tag  string   `custom:"tag" validate:"required"`
 			}
 		}
-
-		os.Clearenv()
-		setenv(t, "MYAPP_HOST", "0.0.0.0")
-		setenv(t, "MYAPP_PORTS", "[8888,443]")
-		setenv(t, "MYAPP_LOGGER_METADATA_TAG", "errorLogger")
-		setenv(t, "MYAPP_LOGGER_LOG_LEVEL", "error")
-		setenv(t, "MYAPP_APPLICATION_VERSION", "1")
-		setenv(t, "MYAPP_CACHE_CLEANUP_INTERVAL", "5m")
-		setenv(t, "MYAPP_CACHE_THRESHOLD", "0.85")
-
-		var want Server
-		want.Host = "0.0.0.0"
-		want.Ports = []int{8888, 443}
-		want.Logger.LogLevel = "error"
-		want.Logger.Metadata.Keys = []string{"ts"}
-		want.Application.BuildDate = time.Date(2012, 12, 25, 0, 0, 0, 0, time.UTC)
-		want.Logger.Metadata.Tag = "errorLogger"
-		want.Application.Version = 1
-		want.Cache.CleanupInterval = 5 * time.Minute
-		want.Cache.FillThreshold = 0.85
-
-		var cfg Server
-
-		err := Load(&cfg,
-			NoFile(),
-			Tag("custom"),
-			TimeLayout("01-02-2006"),
-			UseEnv("myapp"),
-		)
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
+		Cache struct {
+			CleanupInterval time.Duration `custom:"cleanup_interval" validate:"required"`
+			FillThreshold   float32       `custom:"threshold" default:"0.9"`
 		}
-
-		if !reflect.DeepEqual(want, cfg) {
-			t.Errorf("\nwant %+v\ngot %+v", want, cfg)
+		Application struct {
+			BuildDate time.Time `custom:"build_date" default:"12-25-2012"`
+			Version   int
 		}
-	})
+	}
 
+	os.Clearenv()
+	setenv(t, "MYAPP_HOST", "0.0.0.0")
+	setenv(t, "MYAPP_PORTS", "[8888,443]")
+	setenv(t, "MYAPP_LOGGER_METADATA_TAG", "errorLogger")
+	setenv(t, "MYAPP_LOGGER_LOG_LEVEL", "error")
+	setenv(t, "MYAPP_APPLICATION_VERSION", "1")
+	setenv(t, "MYAPP_CACHE_CLEANUP_INTERVAL", "5m")
+	setenv(t, "MYAPP_CACHE_THRESHOLD", "0.85")
+
+	var want Server
+	want.Host = "0.0.0.0"
+	want.Ports = []int{8888, 443}
+	want.Logger.LogLevel = "error"
+	want.Logger.Metadata.Keys = []string{"ts"}
+	want.Application.BuildDate = time.Date(2012, 12, 25, 0, 0, 0, 0, time.UTC)
+	want.Logger.Metadata.Tag = "errorLogger"
+	want.Application.Version = 1
+	want.Cache.CleanupInterval = 5 * time.Minute
+	want.Cache.FillThreshold = 0.85
+
+	var cfg Server
+
+	err := Load(&cfg,
+		IgnoreFile(),
+		Tag("custom"),
+		TimeLayout("01-02-2006"),
+		UseEnv("myapp"),
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if !reflect.DeepEqual(want, cfg) {
+		t.Errorf("\nwant %+v\ngot %+v", want, cfg)
+	}
 }
+
 func Test_fig_findCfgFile(t *testing.T) {
 	t.Run("finds existing file", func(t *testing.T) {
 		fig := defaultFig()

--- a/fig_test.go
+++ b/fig_test.go
@@ -405,6 +405,66 @@ func Test_fig_Load_WithOptions(t *testing.T) {
 	}
 }
 
+func Test_fig_Load_NoFile(t *testing.T) {
+	t.Run("NOFILE", func(t *testing.T) {
+		type Server struct {
+			Host   string `custom:"host" default:"127.0.0.1"`
+			Ports  []int  `custom:"ports" default:"[80,443]"`
+			Logger struct {
+				LogLevel string `custom:"log_level"`
+				Metadata struct {
+					Keys []string `custom:"keys" default:"ts"`
+					Tag  string   `custom:"tag" validate:"required"`
+				}
+			}
+			Cache struct {
+				CleanupInterval time.Duration `custom:"cleanup_interval" validate:"required"`
+				FillThreshold   float32       `custom:"threshold" default:"0.9"`
+			}
+			Application struct {
+				BuildDate time.Time `custom:"build_date" default:"12-25-2012"`
+				Version   int
+			}
+		}
+
+		os.Clearenv()
+		setenv(t, "MYAPP_HOST", "0.0.0.0")
+		setenv(t, "MYAPP_PORTS", "[8888,443]")
+		setenv(t, "MYAPP_LOGGER_METADATA_TAG", "errorLogger")
+		setenv(t, "MYAPP_LOGGER_LOG_LEVEL", "error")
+		setenv(t, "MYAPP_APPLICATION_VERSION", "1")
+		setenv(t, "MYAPP_CACHE_CLEANUP_INTERVAL", "5m")
+		setenv(t, "MYAPP_CACHE_THRESHOLD", "0.85")
+
+		var want Server
+		want.Host = "0.0.0.0"
+		want.Ports = []int{8888, 443}
+		want.Logger.LogLevel = "error"
+		want.Logger.Metadata.Keys = []string{"ts"}
+		want.Application.BuildDate = time.Date(2012, 12, 25, 0, 0, 0, 0, time.UTC)
+		want.Logger.Metadata.Tag = "errorLogger"
+		want.Application.Version = 1
+		want.Cache.CleanupInterval = 5 * time.Minute
+		want.Cache.FillThreshold = 0.85
+
+		var cfg Server
+
+		err := Load(&cfg,
+			NoFile(),
+			Tag("custom"),
+			TimeLayout("01-02-2006"),
+			UseEnv("myapp"),
+		)
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+
+		if !reflect.DeepEqual(want, cfg) {
+			t.Errorf("\nwant %+v\ngot %+v", want, cfg)
+		}
+	})
+
+}
 func Test_fig_findCfgFile(t *testing.T) {
 	t.Run("finds existing file", func(t *testing.T) {
 		fig := defaultFig()

--- a/option.go
+++ b/option.go
@@ -18,6 +18,19 @@ func File(name string) Option {
 	}
 }
 
+// NoFile returns an option which disables any file lookup
+//
+// This option effectively renders any `File` and `Dir` options useless. This option
+// is most useful in conjunction with the `UseEnv` option when you want to provide
+// config values only via environment variables.
+//
+//   fig.Load(&cfg, fig.NoFile(), fig.UseEnv("my_app"))
+func NoFile() Option {
+	return func(f *fig) {
+		f.ignoreFile = true
+	}
+}
+
 // Dirs returns an option that configures the directories that fig searches
 // to find the configuration file.
 //
@@ -60,12 +73,12 @@ func TimeLayout(layout string) Option {
 }
 
 // UseEnv returns an option that configures fig to additionally load values
-// from the environment, after it has loaded values from a config file.
+// from the environment.
 //
 //   fig.Load(&cfg, fig.UseEnv("my_app"))
 //
-// This is meant to be used in conjunction with loading from a file. There
-// is no support to ONLY load from the environment.
+// By default config values are first loaded from the config file and then from
+// the environment. But if `NoFile` option is also given then config file is omitted.
 //
 // Fig looks for environment variables in the format PREFIX_FIELD_PATH or
 // FIELD_PATH if prefix is empty. Prefix is capitalised regardless of what

--- a/option.go
+++ b/option.go
@@ -18,14 +18,14 @@ func File(name string) Option {
 	}
 }
 
-// NoFile returns an option which disables any file lookup
+// IgnoreFile returns an option which disables any file lookup.
 //
 // This option effectively renders any `File` and `Dir` options useless. This option
 // is most useful in conjunction with the `UseEnv` option when you want to provide
 // config values only via environment variables.
 //
-//   fig.Load(&cfg, fig.NoFile(), fig.UseEnv("my_app"))
-func NoFile() Option {
+//   fig.Load(&cfg, fig.IgnoreFile(), fig.UseEnv("my_app"))
+func IgnoreFile() Option {
 	return func(f *fig) {
 		f.ignoreFile = true
 	}
@@ -77,8 +77,7 @@ func TimeLayout(layout string) Option {
 //
 //   fig.Load(&cfg, fig.UseEnv("my_app"))
 //
-// By default config values are first loaded from the config file and then from
-// the environment. But if `NoFile` option is also given then config file is omitted.
+// Values loaded from the environment overwrite values loaded by the config file (if any).
 //
 // Fig looks for environment variables in the format PREFIX_FIELD_PATH or
 // FIELD_PATH if prefix is empty. Prefix is capitalised regardless of what


### PR DESCRIPTION
The changes add a new `NoFile` option and the new
`fig.ignoreFile` field.

Giving this option to `Load()` will:
- Disable the default file lookup process
- The `File` and `Dir` option still work as before but
  become ineffective in the presence of `NoFile` option.

Signed-off-by: Ravi Shekhar Jethani <rsjethani@gmail.com>