### PR TITLE
Upgrade YAML API to `yaml.v3`

### DIFF
--- a/fig.go
+++ b/fig.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/pelletier/go-toml"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -38,17 +38,17 @@ const (
 // A field can be marked as required by adding a `required` key in the field's struct tag.
 // If a required field is not set by the configuration file an error is returned.
 //
-//   type Config struct {
-//     Env string `fig:"env" validate:"required"` // or just `validate:"required"`
-//   }
+//	type Config struct {
+//	  Env string `fig:"env" validate:"required"` // or just `validate:"required"`
+//	}
 //
 // A field can be configured with a default value by adding a `default` key in the
 // field's struct tag.
 // If a field is not set by the configuration file then the default value is set.
 //
-//  type Config struct {
-//    Level string `fig:"level" default:"info"` // or just `default:"info"`
-//  }
+//	type Config struct {
+//	  Level string `fig:"level" default:"info"` // or just `default:"info"`
+//	}
 //
 // A single field may not be marked as both `required` and `default`.
 func Load(cfg interface{}, options ...Option) error {

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/pelletier/go-toml v1.9.3
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/pelletier/go-toml v1.9.3 h1:zeC5b1GviRUyKYd6OJPvBU/mcVDVoL1OhT17FCt5d
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
The `yaml.v3` package addresses a number of issues that had been lingering around the previous API version - namely, string-keyed maps for nested maps. With the upgrade to `yaml.v3` nested maps, where all keys are a string, will be decoded as `map[string]any` rather than `map[any]any`. This is inline with the `encoding/json` package and more streamlined when working with both JSON and YAML. 

Upgrading the package continues to pass all tests. 

https://ubuntu.com/blog/api-v3-of-the-yaml-package-for-go-is-available