### PR TITLE
Add strict parsing option

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -160,6 +160,11 @@ Change the layout fig uses to parse times using `TimeLayout()`.
 
 By default fig parses time using the `RFC.3339` layout (`2006-01-02T15:04:05Z07:00`).
 
+# Strict Parsing
+
+By default fig ignores any fields in the config file that are not present in the struct. This behaviour can be changed using `UseStrict()` to achieve strict parsing.
+When strict parsing is enabled, extra fields in the config file will cause an error.
+
 Required
 
 A validate key with a required value in the field's struct tag makes fig check if the field has been set after it's been loaded. Required fields that are not set are returned as an error.

--- a/fig.go
+++ b/fig.go
@@ -76,6 +76,7 @@ type fig struct {
 	tag        string
 	timeLayout string
 	useEnv     bool
+	useStrict  bool
 	ignoreFile bool
 	envPrefix  string
 }
@@ -156,6 +157,7 @@ func (f *fig) decodeMap(m map[string]interface{}, result interface{}) error {
 		WeaklyTypedInput: true,
 		Result:           result,
 		TagName:          f.tag,
+		ErrorUnused:      f.useStrict,
 		DecodeHook: mapstructure.ComposeDecodeHookFunc(
 			mapstructure.StringToTimeDurationHookFunc(),
 			mapstructure.StringToTimeHookFunc(f.timeLayout),

--- a/option.go
+++ b/option.go
@@ -105,3 +105,16 @@ func UseEnv(prefix string) Option {
 		f.envPrefix = prefix
 	}
 }
+
+// UseStrict returns an option that configures fig to return an error if
+// there exists additional fields in the config file that are not defined
+// in the config struct.
+//
+//	fig.Load(&cfg, fig.UseStrict())
+//
+// If this option is not used then fig ignores any additional fields in the config file.
+func UseStrict() Option {
+	return func(f *fig) {
+		f.useStrict = true
+	}
+}


### PR DESCRIPTION
It's useful to fail when extra keys are present in the config file. Strict parsing is akin to json.DisallowUnknownFields and yaml.UnmarshalStrict and returns an error upon encountering an unknown field.

Fixes: https://github.com/kkyr/fig/issues/18