### PR TITLE
feat: specify env var name in config

### DIFF
--- a/examples/namedenv/config.yaml
+++ b/examples/namedenv/config.yaml
@@ -1,0 +1,5 @@
+winrm:
+  user: 'ci-robot'
+  pwd: '${CI_CONNECT_PWD}'
+
+lock_msg: 'is locked by CI'

--- a/examples/namedenv/namedenv_test.go
+++ b/examples/namedenv/namedenv_test.go
@@ -1,0 +1,41 @@
+package namedenv
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/kkyr/fig"
+)
+
+type Config struct {
+	Winrm struct {
+		User string `validate:"required" fig:"user"`
+		Pwd  string `validate:"required" fig:"pwd"`
+	} `fig:"winrm"`
+
+	LockMsg string `fig:"lock_msg"`
+}
+
+func ExampleLoad() {
+	os.Clearenv()
+	check(os.Setenv("CI_CONNECT_PWD", "securepassword"))
+
+	var cfg Config
+	err := fig.Load(&cfg, fig.UseNamedEnv())
+	check(err)
+
+	fmt.Println(cfg.Winrm.User)
+	fmt.Println(cfg.Winrm.Pwd)
+	fmt.Println(cfg.LockMsg)
+
+	// Output:
+	// ci-robot
+	// securepassword
+	// is locked by CI
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}

--- a/fig.go
+++ b/fig.go
@@ -205,7 +205,7 @@ func namedEnvHookFunc(skip bool) mapstructure.DecodeHookFunc {
 		//nolint:forcetypeassert
 		dataValue := data.(string)
 
-		if !(strings.HasPrefix(dataValue, openToken) && strings.HasPrefix(dataValue, closeToken)) {
+		if !(strings.HasPrefix(dataValue, openToken) && strings.HasSuffix(dataValue, closeToken)) {
 			return data, nil
 		}
 

--- a/fig.go
+++ b/fig.go
@@ -189,7 +189,8 @@ func stringToRegexpHookFunc() mapstructure.DecodeHookFunc {
 	}
 }
 
-// namedEnvHookFunc returns a DecodeHookFunc that returns value of env variable, named in config.
+// namedEnvHookFunc returns a DecodeHookFunc that returns value of env variable,
+// if variable name specified in config.
 func namedEnvHookFunc(skip bool) mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,

--- a/option.go
+++ b/option.go
@@ -71,6 +71,12 @@ func TimeLayout(layout string) Option {
 	}
 }
 
+func UseNamedEnv() Option {
+	return func(f *fig) {
+		f.useNamedEnv = true
+	}
+}
+
 // UseEnv returns an option that configures fig to additionally load values
 // from the environment.
 //

--- a/option.go
+++ b/option.go
@@ -59,7 +59,7 @@ func Tag(tag string) Option {
 	}
 }
 
-// TimeLayout returns an option that conmfigures the time layout that fig uses when
+// TimeLayout returns an option that configures the time layout that fig uses when
 // parsing a time in a config file or in the default tag for time.Time fields.
 //
 //	fig.Load(&cfg, fig.TimeLayout("2006-01-02"))
@@ -71,6 +71,10 @@ func TimeLayout(layout string) Option {
 	}
 }
 
+// UseNamedEnv returns an option that configures fig to load values
+// from the environment for specified in config variable names
+//
+//	fig.Load(&cfg, fig.UseNamedEnv())
 func UseNamedEnv() Option {
 	return func(f *fig) {
 		f.useNamedEnv = true


### PR DESCRIPTION
Add another approach to use env variables by specifying variable name in config file with syntax `somevar: '${VAR}'`