### PR TITLE
field.path: make squash-aware

### DIFF
--- a/fig.go
+++ b/fig.go
@@ -213,7 +213,8 @@ func stringToRegexpHookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
@@ -264,7 +265,7 @@ func (f *fig) processCfg(cfg interface{}) error {
 
 	for _, field := range fields {
 		if err := f.processField(field); err != nil {
-			errs[field.path()] = err
+			errs[field.path(f.tag)] = err
 		}
 	}
 
@@ -283,7 +284,7 @@ func (f *fig) processField(field *field) error {
 	}
 
 	if f.useEnv {
-		if err := f.setFromEnv(field.v, field.path()); err != nil {
+		if err := f.setFromEnv(field.v, field.path(f.tag)); err != nil {
 			return fmt.Errorf("unable to set from env: %w", err)
 		}
 	}

--- a/fig_test.go
+++ b/fig_test.go
@@ -205,6 +205,31 @@ func Test_fig_Load_FileNotFound(t *testing.T) {
 	}
 }
 
+func Test_fig_Load_AllowNoFile(t *testing.T) {
+	fig := defaultFig()
+	fig.filename = "abrakadabra"
+	fig.allowNoFile = true
+	fig.useEnv = true
+	fig.envPrefix = ""
+
+	// Ensure that we still load values via env without a file
+	expectedKind := "this is required"
+	t.Setenv("KIND", expectedKind)
+	t.Setenv("METADATA_MASTER", "true")
+
+	var cfg Pod
+	err := fig.Load(&cfg)
+	if err != nil {
+		t.Fatalf("expected no err, got %v", err)
+	}
+	if cfg.Kind != expectedKind {
+		t.Fatalf("expected %q, got %q", expectedKind, cfg.Kind)
+	}
+	if cfg.Metadata.Master != true {
+		t.Fatalf("expected %t, got %v", true, cfg.Metadata.Master)
+	}
+}
+
 func Test_fig_Load_NonStructPtr(t *testing.T) {
 	cfg := struct {
 		X int

--- a/option.go
+++ b/option.go
@@ -118,3 +118,17 @@ func UseStrict() Option {
 		f.useStrict = true
 	}
 }
+
+// AllowNoFile returns an option that configures fig to proceed even when no config
+// file is found. Loading defaults and values from environment variables will still
+// work as expected.
+//
+//	fig.Load(&cfg, fig.AllowNoFile())
+//
+// If this option is not used then fig returns [ErrFileNotFound] as soon as none are
+// discovered.
+func AllowNoFile() Option {
+	return func(f *fig) {
+		f.allowNoFile = true
+	}
+}


### PR DESCRIPTION
Since fig relies on mapstructure, fields can be annotated with `",squash"` to flatten the config. It's super helpful for base settings that are embedded.

However, because the environment variable resolution relies on field.path(), it doesn't match the config-file structure.

This makes field.path() omit squashed fields.

Example config that's affected:

```yml
env: prod
logging:
  level: info
```

Example structs:

```go
type Base struct {
  Env string `fig:"env"`
  Logging struct {
    Level string `fig:"level"`
  } `fig:"logging"`
}

type Config struct {
  Base `fig:",squash"`
}
```

Overriding with env var before and after this change:

```bash
# before
BASE_ENV=staging
# after
ENV=staging
```