### PR TITLE
field.path: make squash-aware

### DIFF
--- a/fig.go
+++ b/fig.go
@@ -213,7 +213,8 @@ func stringToRegexpHookFunc() mapstructure.DecodeHookFunc {
 	return func(
 		f reflect.Type,
 		t reflect.Type,
-		data interface{}) (interface{}, error) {
+		data interface{},
+	) (interface{}, error) {
 		if f.Kind() != reflect.String {
 			return data, nil
 		}
@@ -264,7 +265,7 @@ func (f *fig) processCfg(cfg interface{}) error {
 
 	for _, field := range fields {
 		if err := f.processField(field); err != nil {
-			errs[field.path()] = err
+			errs[field.path(f.tag)] = err
 		}
 	}
 
@@ -283,7 +284,7 @@ func (f *fig) processField(field *field) error {
 	}
 
 	if f.useEnv {
-		if err := f.setFromEnv(field.v, field.path()); err != nil {
+		if err := f.setFromEnv(field.v, field.path(f.tag)); err != nil {
 			return fmt.Errorf("unable to set from env: %w", err)
 		}
 	}


### PR DESCRIPTION
Since fig relies on mapstructure, fields can be annotated with `",squash"` to flatten the config. It's super helpful for base settings that are embedded.

However, because the environment variable resolution relies on field.path(), it doesn't match the config-file structure.

This makes field.path() omit squashed fields.

Example config that's affected:

```yml
env: prod
logging:
  level: info
```

Example structs:

```go
type Base struct {
  Env string `fig:"env"`
  Logging struct {
    Level string `fig:"level"`
  } `fig:"logging"`
}

type Config struct {
  Base `fig:",squash"`
}
```

Overriding with env var before and after this change:

```bash
BASE_ENV=staging # before
ENV=staging      # after
```